### PR TITLE
Added empty msgid check, improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The function takes the message string as its sole argument and should return the
 
 #### options.header
 Type: `Array`
-Default value: undefined
+Default value: `undefined`
 
 An array in which you may define any headers you want to appear in the .pot file, such as project id,
 creation and revision dates, content type, encodings, etc.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ may come in handy, for example, if you want to simplify whitespace.
 
 The function takes the message string as its sole argument and should return the processed message.
 
+#### options.header
+Type: `Array`
+Default value: undefined
+
+An array in which you may define any headers you want to appear in the .pot file, such as project id,
+creation and revision dates, content type, encodings, etc.
+
+The array elements should be strings, ending with escaped '\n':
+
+```js
+header: [
+    '"Project-Id-Version: KypyMypy\\n"',
+    '"POT-Creation-Date: ' + (new Date()).toString() + '\\n"',
+    '"PO-Revision-Date: ' + (new Date()).toString() + '\\n"',
+    '"Content-Type: text/plain; charset=UTF-8\\n"',
+    '"Content-Transfer-Encoding: 8bit\\n"'
+]
+```
+
 ### Files
 
 #### files.handlebars

--- a/tasks/xgettext.js
+++ b/tasks/xgettext.js
@@ -55,6 +55,10 @@ module.exports = function(grunt) {
             contents += "\n";
         }
 
+        translations = _.filter(translations, function(definition) {
+            return (definition.singular != "");
+        });
+
         contents += _.map(translations, function(definition) {
             var buffer = "";
             if (definition.comment) {

--- a/tasks/xgettext.js
+++ b/tasks/xgettext.js
@@ -55,9 +55,7 @@ module.exports = function(grunt) {
             contents += "\n";
         }
 
-        translations = _.filter(translations, function(definition) {
-            return (definition.singular != "");
-        });
+        translations = _.filter(translations, 'singular');
 
         contents += _.map(translations, function(definition) {
             var buffer = "";


### PR DESCRIPTION
I have added a filter which removes any messages with empty msgid, as they break the header detection. Also, added some documentation with an example for options.header as it was missing from README.md.